### PR TITLE
Add support to delete headers in request

### DIFF
--- a/cmd/revprox/main.go
+++ b/cmd/revprox/main.go
@@ -18,6 +18,7 @@ func main() {
 		path          = flag.String("path", "", "override the request path")
 		extraRequest  = flag.String("extra-request", "", "extra comma-separated request headers to send to the upstream")
 		extraResponse = flag.String("extra-response", "", "extra comma-separated response headers to send back to the client")
+		deleteRequest = flag.String("delete-request", "", "comma-separated request headers to be removed before sending to the upstream")
 		authRealm     = flag.String("auth-realm", "Restricted", "http basic auth realm (frontend)")
 		authUsername  = flag.String("auth-user", "admin", "http basic auth username (frontend)")
 		authPassword  = flag.String("auth-pass", "", "http basic auth password (frontend)")
@@ -44,6 +45,7 @@ func main() {
 		Path:          *path,
 		ExtraRequest:  *extraRequest,
 		ExtraResponse: *extraResponse,
+		DeleteRequest: *deleteRequest,
 		AuthRealm:     *authRealm,
 		AuthUsername:  *authUsername,
 		AuthPassword:  *authPassword,

--- a/revprox.go
+++ b/revprox.go
@@ -23,6 +23,7 @@ type Proxy struct {
 	Path          string
 	ExtraRequest  string
 	ExtraResponse string
+	DeleteRequest string
 	AuthRealm     string
 	AuthUsername  string
 	AuthPassword  string
@@ -78,6 +79,11 @@ func (p *Proxy) init() {
 			for _, h := range strings.Split(p.ExtraRequest, ",") {
 				s := strings.Split(h, ":")
 				req.Header.Set(s[0], s[1])
+			}
+		}
+		if len(p.DeleteRequest) > 0 {
+			for _, h := range strings.Split(p.DeleteRequest, ",") {
+				req.Header.Del(h)
 			}
 		}
 		if p.AccessLog {


### PR DESCRIPTION
This pull request adds a new argument called `delete-request` so that specific header fields can be deleted before sending request to upstream.

One use case is when basic auth is enabled in revproxy and upstream service, the `Authorization` header is passed to upstream service and will cause authentication failure if username/password are not same in revproxy and the upstream service.